### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,8 +136,8 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dependencies": {
         "lodash": "4.17.21"
@@ -330,7 +330,7 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dependencies": {
-        "minimist": "1.2.5",
+        "minimist": "1.2.6",
         "neo-async": "2.6.2",
         "source-map": "0.6.1",
         "wordwrap": "1.0.0"
@@ -452,7 +452,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mkdirp": {
@@ -460,7 +460,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dependencies": {
-        "minimist": "1.2.5"
+        "minimist": "1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -532,7 +532,7 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
       "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
       "dependencies": {
-        "async": "2.6.3",
+        "async": "2.6.4",
         "debug": "3.2.7",
         "mkdirp": "0.5.5"
       },
@@ -1902,7 +1902,7 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dependencies": {
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
@@ -2287,8 +2287,8 @@
       }
     },
     "node_modules/redoc-cli/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/redoc-cli/node_modules/mkdirp": {
@@ -2619,8 +2619,8 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
     "node_modules/redoc-cli/node_modules/prismjs": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
       "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==",
       "engines": {
         "node": ">=6"
@@ -2816,7 +2816,7 @@
         "path-browserify": "^1.0.1",
         "perfect-scrollbar": "^1.5.1",
         "polished": "^4.1.3",
-        "prismjs": "^1.24.1",
+        "prismjs": ">=1.27.0",
         "prop-types": "^15.7.2",
         "react-tabs": "^3.2.2",
         "slugify": "~1.4.7",
@@ -3882,8 +3882,8 @@
       }
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
         "lodash": "4.17.21"
@@ -4043,7 +4043,7 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "requires": {
-        "minimist": "1.2.5",
+        "minimist": "1.2.6",
         "neo-async": "2.6.2",
         "source-map": "0.6.1",
         "uglify-js": "3.15.1",
@@ -4132,8 +4132,8 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
@@ -4141,7 +4141,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "1.2.5"
+        "minimist": "1.2.6"
       }
     },
     "ms": {
@@ -4195,7 +4195,7 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
       "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
       "requires": {
-        "async": "2.6.3",
+        "async": "2.6.4",
         "debug": "3.2.7",
         "mkdirp": "0.5.5"
       }
@@ -5397,7 +5397,7 @@
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
           "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
           "requires": {
-            "minimist": "^1.2.5",
+            "minimist": "^1.2.6",
             "neo-async": "^2.6.0",
             "source-map": "^0.6.1",
             "uglify-js": "^3.1.4",
@@ -5696,8 +5696,8 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mkdirp": {
@@ -5937,8 +5937,8 @@
           "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
         },
         "prismjs": {
-          "version": "1.26.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
           "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ=="
         },
         "process": {
@@ -6116,7 +6116,7 @@
             "path-browserify": "^1.0.1",
             "perfect-scrollbar": "^1.5.1",
             "polished": "^4.1.3",
-            "prismjs": "^1.24.1",
+            "prismjs": ">=1.27.0",
             "prop-types": "^15.7.2",
             "react-tabs": "^3.2.2",
             "slugify": "~1.4.7",


### PR DESCRIPTION
This PR updates dependencies versions in order to correct [some issues](https://github.com/mconf/mconf-api-docs/security/dependabot) warned by Dependabot in this repository.

### async: 2.6.3 -> 2.6.4
### prismjs: 1.26.0 -> 1.27.0
### minimist: 1.2.5 -> 1.2.6